### PR TITLE
Fix HTML report saved in default encoding instead of UTF-8

### DIFF
--- a/src/main/java/org/codehaus/mojo/clirr/ClirrReport.java
+++ b/src/main/java/org/codehaus/mojo/clirr/ClirrReport.java
@@ -42,9 +42,12 @@ import org.codehaus.plexus.util.PathTool;
 import org.codehaus.plexus.util.StringUtils;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Locale;
@@ -190,8 +193,10 @@ public class ClirrReport
             generate( sink, locale );
 
             outputDirectory.mkdirs();
+            
+            FileOutputStream stream = new FileOutputStream(new File( outputDirectory, getOutputName() + ".html" ));
 
-            Writer writer = new FileWriter( new File( outputDirectory, getOutputName() + ".html" ) );
+            Writer writer = new OutputStreamWriter( stream, StandardCharsets.UTF_8 );
 
             siteRenderer.generateDocument( writer, sink, siteContext );
 


### PR DESCRIPTION
mvn clirr:clirr wrote the generated .html file in system default encoding instead of UTF-8. This resulted in non-displayable characters on Windows machines with german (and potentially other) language encoding:

![image](https://cloud.githubusercontent.com/assets/3154071/19598703/71ddb912-979c-11e6-8db7-96ad424c447b.png)
