### PR TITLE
Exclude classes based on annotations

### DIFF
--- a/src/main/java/org/codehaus/mojo/clirr/AbstractClirrMojo.java
+++ b/src/main/java/org/codehaus/mojo/clirr/AbstractClirrMojo.java
@@ -186,6 +186,15 @@ public abstract class AbstractClirrMojo
     protected String[] excludes;
 
     /**
+     * A list of annotations marking special classes and interfaces to be excluded from comparison.
+     * Classes annotated with these annotations are excluded from the list of classes that are included.
+     * Values are specified in class name notation, e.g. <code>java.lang.Deprecated</code>.
+     *
+     * @parameter
+     */
+    protected String[] excludeAnnotated;
+
+    /**
      * A list of differences reported by Clirr that should be ignored when producing the final report.
      * Values specified here will be joined with the ones specified using the "ignoredDifferencesFile"
      * parameter.
@@ -258,7 +267,7 @@ public abstract class AbstractClirrMojo
     {
         ClirrDiffListener listener = new ClirrDiffListener();
 
-        ClassFilter classFilter = new ClirrClassFilter( includes, excludes );
+        ClassFilter classFilter = new ClirrClassFilter( includes, excludes, excludeAnnotated );
 
         JavaType[] origClasses = resolvePreviousReleaseClasses( classFilter );
 

--- a/src/main/java/org/codehaus/mojo/clirr/ClirrArbitraryCheckMojo.java
+++ b/src/main/java/org/codehaus/mojo/clirr/ClirrArbitraryCheckMojo.java
@@ -239,7 +239,7 @@ public class ClirrArbitraryCheckMojo
     {
         ClirrDiffListener listener = new ClirrDiffListener();
 
-        ClassFilter classFilter = new ClirrClassFilter( includes, excludes );
+        ClassFilter classFilter = new ClirrClassFilter( includes, excludes, excludeAnnotated );
 
         JavaType[] origClasses = resolveClasses( oldComparisonArtifacts, classFilter );
 


### PR DESCRIPTION
Please consider adding an option to exclude classes from comparison based on annotations. There are projects like Apache HttpComponents, Apache Lucene and I suppose many others that use custom annotations to mark certain APIs as internal, experimental or unstable which one might want to exclude from compatibility analysis.